### PR TITLE
routes_modify-finish

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root "infos#index"
-  resources :infos, only: [:new, :create, :show, :destroy] do
-    resources :comments, only: [:index]
+  resources :infos, only: [:destroy] do
+    resources :comments, only: [:new, :create, :show, :destroy]
   end
 end


### PR DESCRIPTION
#what
アプリのルーティングが間違っていた為、修正

#why
コメント機能を新しく作成する際に、どの情報のコメントかを識別するために、infosにネストされているcommentsにnewを入れる必要があったため。
これにより、以下のURLを生成することができて、どの情報にコメントを追加するか識別できるようにした。
/infos/:info_id/comments/new(.:format)